### PR TITLE
feat: add remi vu fady tools

### DIFF
--- a/packages/5rn/fady/package.py
+++ b/packages/5rn/fady/package.py
@@ -1,21 +1,12 @@
-# -*- coding: utf-8 -*-
-name = 'fady'
-version = '1.0'
+name = "fady"
+version = "1.0"
 
-authors = ['ArtFx TD gang']
+authors = ["ArtFx TD gang"]
 
 requires = [
-    'vray',
-    'aces',
+    "vray",
+    "aces",
 ]
-
-timestamp = 1635410671
-
-vcs = 'git'
-
-format_version = 2
-
-
 
 
 def commands():
@@ -23,8 +14,11 @@ def commands():
     Set the environment variables for Houdini
     """
 
-    #DMNK TOOLS
+    # DMNK TOOLS
     env.HOUDINI_PATH.append("C:/Users/etudiant/Documents/houdini18.5/DMNK-Tools-master")
 
-    #MOPS
+    # MOPS
     env.HOUDINI_PATH.append("C:/Users/etudiant/Documents/houdini18.5/MOPS")
+
+    # rvu packages
+    env.HOUDINI_PACKAGE_DIR.append("C:/Users/etudiant/Documents/houdini18.5/packages")

--- a/packages/dcc/maya/2022.0/package.py
+++ b/packages/dcc/maya/2022.0/package.py
@@ -25,6 +25,7 @@ tools = [
 def commands():
     # Set this variable to your maya install path
     maya_install_path = "C:/Maya2022/Maya2022"
+    env.PYTHONPATH.append("//marvin/installers/WIN/AnimBot")  # noqa
 
     env.PATH.append(f"{maya_install_path}/bin")  # noqa
     #env.PYTHONPATH.append(f"{maya_install_path}/Python37/Lib/site-packages")  # noqa


### PR DESCRIPTION
This pull request is adding remi vu's houdini packages to `HOUDINI_PATH`. It would be better to add it for the user in question rather than the whole team but it involves having a user package that is optional (`rez env fady rvu houdini -- houdini`)